### PR TITLE
chore: add AMD64 deployment support

### DIFF
--- a/.github/ISSUE_TEMPLATE/01-feature.md
+++ b/.github/ISSUE_TEMPLATE/01-feature.md
@@ -1,0 +1,16 @@
+---
+name: Feature
+about: Propose a change or new feature
+labels: ["enhancement"]
+---
+
+## Goal
+
+## Why
+
+## Proposal
+
+## Acceptance criteria
+- [ ]
+
+## Notes

--- a/.github/ISSUE_TEMPLATE/02-bug.md
+++ b/.github/ISSUE_TEMPLATE/02-bug.md
@@ -1,0 +1,19 @@
+---
+name: Bug
+about: Report something broken
+labels: ["bug"]
+---
+
+## What happened
+
+## Expected
+
+## Steps to reproduce
+1.
+
+## Environment
+- OS:
+- Podman version:
+- Image/tag:
+
+## Logs

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to the Ollama LLM Capability will be documented in this file
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- AMD64 (x86-64) deployment presets: `podman-compose.amd64.yml`, `config/amd64-24gb.yml`, `config/amd64-32gb.yml`
+- Dedicated AMD64 deployment guide (`docs/deployment-guide-amd64.md`)
+- AMD64 device profiles in `config/device-constraints.json`
+
+### Changed
+- Capability contract now supports multi-architecture metadata via `target_platforms` and `supported_architectures`
+- Documentation updated to reflect Raspberry Pi (ARM64) and AMD64 support across deployment, tuning, and architecture docs
+
+### Fixed
+- Documentation references to a non-existent `Containerfile` rebuild path
+- General troubleshooting guidance for environments missing `curl`
+
 ## [1.0.0] - 2026-01-14
 
 ### Added
@@ -36,3 +51,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Deployment roadmap
 
 [1.0.0]: https://github.com/eZansiEdgeAI/ezansi-capability-llm-ollama/releases/tag/v1.0.0
+[Unreleased]: https://github.com/eZansiEdgeAI/ezansi-capability-llm-ollama/compare/v1.0.0...HEAD

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # ezansi-capability-llm-ollama
 
-Ollama LLM Capability for eZansiEdgeAI — a modular, containerized text-generation service designed to run on Raspberry Pi 5.
+Ollama LLM Capability for eZansiEdgeAI — a modular, containerized text-generation service designed for Raspberry Pi (ARM64) and AMD64 (x86-64) Linux systems.
 
 **Provides:** `text-generation`  
-**Target device:** Raspberry Pi 5 (16GB)  
+**Target devices:** Raspberry Pi 4/5 (ARM64) and AMD64 hosts (24GB+)  
 **Deployment method:** Podman + podman-compose
 
 ---
@@ -56,10 +56,12 @@ Runs a local LLM using [Ollama](https://ollama.ai) in a containerized environmen
 
 ## Resource Requirements
 
+The default `podman-compose.yml` is tuned for Raspberry Pi class hardware. For AMD64 systems (24GB+), use the AMD64 compose/config presets.
+
 | Resource | Requirement |
 |----------|-------------|
-| RAM      | 6 GB (limit), 4 GB (reserved) |
-| CPU      | 4 cores (recommended Pi 5 minimum) |
+| RAM      | 6 GB (limit), 4 GB (reserved) (default Pi-friendly config) |
+| CPU      | 4 cores (default Pi-friendly config) |
 | Storage  | 8 GB+ (for model data) |
 | Disk I/O | SSD or USB 3.0+ recommended |
 
@@ -67,12 +69,22 @@ Runs a local LLM using [Ollama](https://ollama.ai) in a containerized environmen
 
 ## Prerequisites
 
-### 1. Prepare Your Raspberry Pi 5
+### 1. Prepare Your Device (Raspberry Pi or AMD64)
 
-Ensure your Pi is running a supported OS (Raspberry Pi OS 64-bit recommended) and has:
+- **Raspberry Pi:** Raspberry Pi OS 64-bit recommended.
+- **AMD64:** Ubuntu/Debian/RHEL-like Linux works well (24GB+ RAM recommended).
+
+Ensure your system has:
 - Podman and podman-compose installed
 - User-level Podman access configured
 - Sufficient storage for model data
+
+Install `curl` (used by scripts and examples):
+
+```bash
+sudo apt update
+sudo apt install -y curl
+```
 
 **Installation commands:**
 
@@ -165,9 +177,11 @@ systemctl --user restart podman.socket
 systemctl --user is-active podman.socket
 ```
 
-### 3. Enable Memory Controller in cgroups (Required for Resource Limits)
+### 3. Enable Memory Controller in cgroups (Raspberry Pi Only)
 
-**Why this matters:** Podman resource limits (memory, CPU) require the memory controller to be enabled in cgroups. This must be explicitly configured via boot parameters on Raspberry Pi OS.
+**Why this matters:** Podman resource limits (memory, CPU) require the memory controller to be enabled in cgroups. On Raspberry Pi OS this can require boot parameters.
+
+On most AMD64 Linux distributions, the memory controller is already enabled. If it is not, the fix is distro/bootloader specific (do not copy Raspberry Pi boot parameters).
 
 **Check if memory controller is available:**
 
@@ -215,7 +229,7 @@ For troubleshooting, see [docs/troubleshooting.md](docs/troubleshooting.md#memor
 ### 4. Clone This Repository
 
 ```bash
-git clone https://github.com/your-org/ezansi-capability-llm-ollama.git
+git clone https://github.com/eZansiEdgeAI/ezansi-capability-llm-ollama.git
 cd ezansi-capability-llm-ollama
 ```
 
@@ -225,12 +239,19 @@ cd ezansi-capability-llm-ollama
 
 Now that you have the prerequisites in place, next step is to deploy and test the Ollama LLM capability.
 
+For a full AMD64 walkthrough (24GB+ RAM presets), see [docs/deployment-guide-amd64.md](docs/deployment-guide-amd64.md).
+
 ### Step 1: Start the Ollama Container
 
 From the repository root, run:
 
 ```bash
+# Raspberry Pi / low-resource default
 podman-compose up -d
+
+# AMD64 (x86-64) with 24GB+ RAM
+podman-compose -f config/amd64-24gb.yml up -d
+# or: podman-compose -f podman-compose.amd64.yml up -d
 ```
 
 This will:
@@ -283,13 +304,18 @@ Once a model is loaded, generate text:
 
 ```bash
 curl -X POST http://localhost:11434/api/generate \
-  -d '{"model":"mistral","prompt":"Explain quantum computing in one sentence"}' \
+  -d '{"model":"mistral","prompt":"Explain quantum computing in one sentence", "stream":false}' \
   -H "Content-Type: application/json"
 ```
 
 For streaming responses:
 
 ```bash
+# Stream the response tokens in real-time
+curl -X POST http://localhost:11434/api/generate \
+  -d '{"model":"mistral","prompt":"Explain quantum computing in one sentence", "stream":false}' \
+  -H "Content-Type: application/json"
+
 # Stream tokens only (hides metadata)
 curl -N -X POST http://localhost:11434/api/generate \
    -d '{"model":"mistral","prompt":"Hello","stream":true}' \
@@ -430,7 +456,8 @@ To add a new capability (e.g., speech-to-text, vision, retrieval), create a simi
     "port": <port>,
     "restart_policy": "unless-stopped"
   },
-  "target_platform": "Raspberry Pi 5"
+   "target_platforms": ["Raspberry Pi 4/5", "AMD64 (24GB+)"],
+   "supported_architectures": ["arm64", "amd64"]
 }
 ```
 
@@ -446,10 +473,11 @@ Comprehensive guides available in `docs/`:
 
 - **[Development Roadmap](docs/development-roadmap.md)** - Multi-phase plan for the capability ecosystem
 - **[Architecture](docs/architecture.md)** - System design and principles
-- **[Performance Tuning](docs/performance-tuning.md)** - Optimization for Pi models
+- **[Performance Tuning](docs/performance-tuning.md)** - Optimization for Pi and AMD64
 - **[Troubleshooting](docs/troubleshooting.md)** - Common issues and solutions
 - **[Capability Contract Spec](docs/capability-contract-spec.md)** - Contract schema details
 - **[Deployment & Portability Guide](docs/deployment-guide.md)** - Container migration strategies
+- **[AMD64 Deployment Guide](docs/deployment-guide-amd64.md)** - Presets for x86-64 systems
 
 ---
 
@@ -489,9 +517,21 @@ cp config/pi4-8gb.yml podman-compose.yml
 podman-compose up -d
 ```
 
+**For AMD64 (x86-64) with 24GB+ RAM:**
+```bash
+# Use the AMD64 preset (24GB)
+podman-compose -f config/amd64-24gb.yml up -d
+
+# Or use the higher-memory preset (32GB+)
+podman-compose -f config/amd64-32gb.yml up -d
+```
+
 **Configuration files available:**
 - **podman-compose.pi5.yml** - Optimized for Pi 5 (12GB limit, supports Mistral)
 - **config/pi5-16gb.yml** - Equivalent config file for Pi 5
+- **config/amd64-24gb.yml** - AMD64 preset (18GB limit / 14GB reserved)
+- **config/amd64-32gb.yml** - AMD64 preset (28GB limit / 24GB reserved)
+- **podman-compose.amd64.yml** - AMD64 default compose (20GB limit / 16GB reserved)
 - **config/pi4-8gb.yml** - Conservative settings for Pi 4 (5GB limit)
 - **device-constraints.json** - Device capability reference
 

--- a/capability.json
+++ b/capability.json
@@ -18,6 +18,7 @@
     "port": 11434,
     "restart_policy": "unless-stopped"
   },
-  "target_platform": "Raspberry Pi 5 (16GB)",
-  "notes": "This capability contract defines the interface for text-generation services in eZansiEdgeAI. Other capabilities must expose the same 'provides' and resource fields."
+  "target_platforms": ["Raspberry Pi 5 (16GB)", "Raspberry Pi 4 (8GB)", "AMD64 (24GB+)"],
+  "supported_architectures": ["arm64", "amd64"],
+  "notes": "This capability contract defines the interface for text-generation services in eZansiEdgeAI. Other capabilities must expose the same 'provides' and resource fields. Supports both ARM64 (Raspberry Pi) and AMD64 (x86-64) architectures."
 }

--- a/config/amd64-24gb.yml
+++ b/config/amd64-24gb.yml
@@ -1,0 +1,35 @@
+version: '3.8'
+
+# Configuration for AMD64 Systems (24GB RAM)
+# Suitable for standard x86-64 workstations and servers
+
+services:
+  ollama:
+    image: docker.io/ollama/ollama
+    container_name: ollama-llm-capability
+    platform: linux/amd64
+    ports:
+      - "11434:11434"
+    volumes:
+      - ollama-data:/root/.ollama
+    deploy:
+      resources:
+        limits:
+          memory: 18g
+          cpus: '8'
+        reservations:
+          memory: 14g
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:11434/api/tags"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
+    environment:
+      - OLLAMA_NUM_PARALLEL=8
+      - OLLAMA_MAX_LOADED_MODELS=3
+
+volumes:
+  ollama-data:
+    driver: local

--- a/config/amd64-32gb.yml
+++ b/config/amd64-32gb.yml
@@ -1,0 +1,35 @@
+version: '3.8'
+
+# Configuration for AMD64 Systems (32GB+ RAM)
+# Suitable for high-performance x86-64 servers
+
+services:
+  ollama:
+    image: docker.io/ollama/ollama
+    container_name: ollama-llm-capability
+    platform: linux/amd64
+    ports:
+      - "11434:11434"
+    volumes:
+      - ollama-data:/root/.ollama
+    deploy:
+      resources:
+        limits:
+          memory: 28g
+          cpus: '16'
+        reservations:
+          memory: 24g
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:11434/api/tags"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
+    environment:
+      - OLLAMA_NUM_PARALLEL=16
+      - OLLAMA_MAX_LOADED_MODELS=4
+
+volumes:
+  ollama-data:
+    driver: local

--- a/config/device-constraints.json
+++ b/config/device-constraints.json
@@ -35,6 +35,30 @@
         "num_parallel": 2,
         "max_loaded_models": 1
       }
+    },
+    {
+      "name": "amd64-24gb",
+      "ram_mb": 24000,
+      "cpu_cores": 8,
+      "recommended_models": ["mistral", "neural-chat", "llama2"],
+      "max_concurrent_requests": 8,
+      "ollama_config": {
+        "memory_limit": "18g",
+        "num_parallel": 8,
+        "max_loaded_models": 3
+      }
+    },
+    {
+      "name": "amd64-32gb",
+      "ram_mb": 32000,
+      "cpu_cores": 16,
+      "recommended_models": ["llama2", "neural-chat", "dolphin-mixtral"],
+      "max_concurrent_requests": 16,
+      "ollama_config": {
+        "memory_limit": "28g",
+        "num_parallel": 16,
+        "max_loaded_models": 4
+      }
     }
   ]
 }

--- a/docs/README.md
+++ b/docs/README.md
@@ -24,7 +24,7 @@ Complete specification for the capability contract schema.
 - Example contracts
 
 ### [Performance Tuning](performance-tuning.md)
-Optimize Ollama for different Raspberry Pi models.
+Optimize Ollama for different Raspberry Pi models and AMD64 systems.
 
 **Topics:**
 - Hardware-specific configurations
@@ -50,6 +50,12 @@ Common issues and solutions.
 - **Testing:** Check [tests/README.md](../tests/README.md)
 - **Configuration:** Browse [config/](../config/)
 
+## AMD64
+
+Running on an x86-64 workstation/server is supported.
+
+- **Deployment (AMD64):** See [deployment-guide-amd64.md](deployment-guide-amd64.md)
+
 ## Documentation Structure
 
 ```
@@ -57,6 +63,8 @@ docs/
 ├── README.md                        # This file
 ├── architecture.md                  # System architecture
 ├── capability-contract-spec.md      # Contract specification
+├── deployment-guide.md              # Portability and deployment patterns
+├── deployment-guide-amd64.md        # AMD64 deployment (24GB+ RAM presets)
 ├── performance-tuning.md            # Optimization guide
 └── troubleshooting.md               # Problem solving
 ```
@@ -68,7 +76,7 @@ When adding or updating documentation:
 1. **Follow Markdown best practices**
 2. **Include code examples** where appropriate
 3. **Link between related documents**
-4. **Keep content Pi-focused** - this is edge hardware
+4. **Keep content edge-focused** - Raspberry Pi is the default target, but AMD64 is supported
 5. **Update this README** when adding new docs
 
 ## External Resources

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -10,6 +10,8 @@ eZansiEdgeAI is a lightweight, modular edge-AI platform where small capability c
 
 Instead of one monolithic AI stack, eZansiEdgeAI provides small, independent capability modules that can be combined in different ways to create learning tools, assistants, and experiments on low-power devices.
 
+The same pattern also works on standard AMD64 (x86-64) Linux systems for development and higher-performance deployments.
+
 **Build once, compose many times.**
 
 ### Three Logical Layers
@@ -78,7 +80,7 @@ This enables:
 ### Minimal System
 
 ```
-Raspberry Pi
+Linux Device (Raspberry Pi / AMD64)
 └── Podman
     ├── platform-registry      (tiny)
     ├── platform-orchestrator  (very thin)

--- a/docs/capability-contract-spec.md
+++ b/docs/capability-contract-spec.md
@@ -16,6 +16,11 @@ Or include it as `capability.json` in the repository root.
 
 ## Schema Definition
 
+This repo supports both Raspberry Pi (ARM64) and AMD64 (x86-64) deployments. For that reason, newer contracts MAY declare multiple targets and architectures.
+
+- Prefer `target_platforms` + `supported_architectures` for new capabilities.
+- `target_platform` remains supported for backwards compatibility, but is treated as deprecated.
+
 ### v1.0 Contract
 
 ```json
@@ -45,7 +50,9 @@ Or include it as `capability.json` in the repository root.
     "port": number,              // Exposed port
     "restart_policy": "string"   // Restart policy
   },
-  "target_platform": "string",   // Optional: Intended hardware
+  "target_platform": "string",   // Optional (deprecated): Intended hardware
+  "target_platforms": ["string"], // Optional: Intended hardware targets
+  "supported_architectures": ["string"], // Optional: e.g. ["arm64", "amd64"]
   "notes": "string"              // Optional: Additional information
 }
 ```
@@ -100,7 +107,8 @@ Capabilities MUST use one of these standard `provides` values:
     "port": 11434,
     "restart_policy": "unless-stopped"
   },
-  "target_platform": "Raspberry Pi 5 (16GB)"
+  "target_platforms": ["Raspberry Pi 5 (16GB)", "Raspberry Pi 4 (8GB)", "AMD64 (24GB+)"],
+  "supported_architectures": ["arm64", "amd64"]
 }
 ```
 
@@ -179,6 +187,7 @@ Resource declarations should be realistic for target hardware:
 | Pi 5 (16GB) | 16GB | ~2GB | ~14GB |
 | Pi 5 (8GB) | 8GB | ~1.5GB | ~6.5GB |
 | Pi 4 (8GB) | 8GB | ~1.5GB | ~6.5GB |
+| AMD64 (32GB) | 32GB | ~2-4GB | ~28-30GB |
 
 ### CPU Cores
 

--- a/docs/deployment-guide-amd64.md
+++ b/docs/deployment-guide-amd64.md
@@ -1,0 +1,415 @@
+# AMD64 Deployment Guide
+
+This guide covers deploying the Ollama LLM capability on x86-64 (AMD64) systems with 24GB or more of RAM.
+
+## System Requirements
+
+### Minimum Requirements
+- **CPU:** 8 cores (Intel/AMD x86-64)
+- **RAM:** 24GB (minimum), 32GB+ recommended
+- **Storage:** 50GB free (for models)
+- **OS:** Linux (Ubuntu 20.04+, CentOS 8+, Debian 11+, or equivalent)
+
+### Recommended Specifications
+- **CPU:** 16+ cores
+- **RAM:** 32GB or more
+- **Storage:** 100GB+ SSD (faster model loading)
+- **GPU:** Optional NVIDIA CUDA support (requires NVIDIA GPU and CUDA runtime)
+
+### Prerequisites
+- Podman or Docker installed (`podman --version` or `docker --version`)
+- `curl` command available
+- Network connectivity to pull the Ollama image
+
+## Quick Start (24GB-32GB Systems)
+
+```bash
+# 1. Clone this repository
+git clone https://github.com/eZansiEdgeAI/ezansi-capability-llm-ollama.git
+cd ezansi-capability-llm-ollama
+
+# 2. Deploy using the AMD64 compose file
+podman-compose -f podman-compose.amd64.yml up -d
+
+# 3. Verify the service is healthy
+./scripts/health-check.sh
+
+# 4. Pull a model
+podman exec ollama-llm-capability ollama pull mistral
+```
+
+## Compose File Selection
+
+Choose the appropriate configuration for your system:
+
+### `podman-compose.amd64.yml` (Recommended for 24GB+)
+- Memory limit: 20GB / 16GB reserved
+- CPU limit: 8 cores
+- Parallel requests: 8
+- Max loaded models: 3
+- **Best for:** Standard x86-64 servers with 24GB-32GB RAM
+
+### `config/amd64-24gb.yml` (Explicit 24GB configuration)
+- Memory limit: 18GB / 14GB reserved
+- CPU limit: 8 cores
+- Parallel requests: 8
+- Max loaded models: 3
+- **Best for:** Systems with exactly 24GB RAM
+
+### `config/amd64-32gb.yml` (High-performance systems)
+- Memory limit: 28GB / 24GB reserved
+- CPU limit: 16 cores
+- Parallel requests: 16
+- Max loaded models: 4
+- **Best for:** Systems with 32GB+ RAM and many CPU cores
+
+## Deployment Methods
+
+### Method 1: Using Podman Compose (Recommended)
+
+```bash
+# Start the service
+podman-compose -f podman-compose.amd64.yml up -d
+
+# Check status
+podman-compose -f podman-compose.amd64.yml ps
+
+# View logs
+podman-compose -f podman-compose.amd64.yml logs -f
+
+# Stop the service
+podman-compose -f podman-compose.amd64.yml down
+```
+
+### Method 2: Using Docker Compose
+
+If you prefer Docker instead of Podman:
+
+```bash
+# Start the service
+docker-compose -f podman-compose.amd64.yml up -d
+
+# Note: The file works with both Podman and Docker
+```
+
+### Method 3: Manual Podman Run
+
+```bash
+# Pull the image
+podman pull docker.io/ollama/ollama
+
+# Create volume for persistence
+podman volume create ollama-data
+
+# Run the container
+podman run -d \
+  --name ollama-llm-capability \
+  -p 11434:11434 \
+  -v ollama-data:/root/.ollama \
+  --memory 20g \
+  --cpus 8 \
+  --restart unless-stopped \
+  -e OLLAMA_NUM_PARALLEL=8 \
+  -e OLLAMA_MAX_LOADED_MODELS=3 \
+  docker.io/ollama/ollama
+
+# Verify it's running
+curl http://localhost:11434/api/tags
+```
+
+## Model Management
+
+### Pulling Models
+
+```bash
+# List available models first (view at https://ollama.ai/library)
+podman exec ollama-llm-capability ollama list
+
+# Pull a model
+podman exec ollama-llm-capability ollama pull mistral
+
+# Pull a larger model (requires more VRAM)
+podman exec ollama-llm-capability ollama pull llama2
+
+# Pull multiple models
+podman exec ollama-llm-capability ollama pull neural-chat
+podman exec ollama-llm-capability ollama pull orca-mini
+```
+
+### Recommended Models for AMD64
+
+Based on available system RAM:
+
+| Model | Size | RAM Required | Best For |
+|-------|------|--------------|----------|
+| `mistral` | 4.1B | 8GB | Fast inference, balanced quality |
+| `neural-chat` | 7B | 12GB | Chat applications, good quality |
+| `llama2` | 7B | 12GB | General purpose, popular |
+| `orca-mini` | 3B | 6GB | Light workloads, embedded systems |
+| `dolphin-mixtral` | MoE | 24GB+ | High quality, requires 32GB+ systems |
+
+### Checking Loaded Models
+
+```bash
+# View all available models
+podman exec ollama-llm-capability ollama list
+
+# Check current memory usage
+podman exec ollama-llm-capability ps aux
+```
+
+### Removing Models
+
+```bash
+# Remove a specific model
+podman exec ollama-llm-capability ollama rm mistral
+
+# List models before deletion
+podman exec ollama-llm-capability ollama list
+```
+
+## API Usage
+
+The Ollama API runs on `localhost:11434` (or your server's IP address).
+
+### Generate Text
+
+```bash
+# Using curl
+curl -X POST http://localhost:11434/api/generate -d '{
+  "model": "mistral",
+  "prompt": "Tell me about edge AI",
+  "stream": false
+}'
+
+# With streaming
+curl -X POST http://localhost:11434/api/generate -d '{
+  "model": "mistral",
+  "prompt": "Tell me about edge AI",
+  "stream": true
+}'
+```
+
+### Remote Access
+
+If accessing from another machine on your network:
+
+```bash
+# On remote client
+curl -X POST http://<server-ip>:11434/api/generate -d '{
+  "model": "mistral",
+  "prompt": "Hello",
+  "stream": false
+}'
+
+# Security note: This exposes the API to your network
+# Consider using a firewall or reverse proxy for production
+```
+
+## Performance Optimization
+
+### Memory Management
+
+The AMD64 configurations are tuned for systems with 24GB+. To optimize for your specific system:
+
+```yaml
+# Edit podman-compose.amd64.yml or your config file
+deploy:
+  resources:
+    limits:
+      memory: 20g        # Adjust based on your RAM
+      cpus: '8'          # Match your CPU count
+```
+
+### CPU Usage
+
+Increase parallel requests for systems with more CPU cores:
+
+```yaml
+environment:
+  - OLLAMA_NUM_PARALLEL=16  # For 16+ core systems
+  - OLLAMA_MAX_LOADED_MODELS=4  # For 32GB+ RAM
+```
+
+### Monitoring Performance
+
+```bash
+# Check container resource usage
+podman stats ollama-llm-capability
+
+# View container logs for performance metrics
+podman logs ollama-llm-capability | grep -i "error\|warning"
+```
+
+## Troubleshooting
+
+### Container Won't Start
+
+```bash
+# Check logs
+podman logs ollama-llm-capability
+
+# Verify image is available
+podman images | grep ollama
+
+# Try pulling the image again
+podman pull docker.io/ollama/ollama
+
+# Check if port 11434 is already in use
+lsof -i :11434
+```
+
+### Out of Memory (OOM)
+
+```bash
+# Check memory limits
+podman stats ollama-llm-capability
+
+# Reduce memory limit in compose file
+# Reduce OLLAMA_MAX_LOADED_MODELS
+# Unload some models: podman exec ollama-llm-capability ollama rm model-name
+```
+
+### Slow Performance
+
+1. **Check system resources:**
+   ```bash
+   top -bn1 | head -20  # CPU usage
+   free -h              # Memory usage
+   df -h                # Disk space
+   ```
+
+2. **Monitor container:**
+   ```bash
+   podman stats ollama-llm-capability
+   ```
+
+3. **Optimize configuration:**
+   - Ensure no system overload
+   - Reduce OLLAMA_NUM_PARALLEL if CPU-bound
+   - Add more memory reservation if RAM-bound
+
+### Model Loading Fails
+
+```bash
+# Check available disk space
+df -h /path/to/ollama-data
+
+# Clear cached data if needed
+podman exec ollama-llm-capability rm -rf /root/.ollama/tmp/*
+
+# Restart the service
+podman-compose -f podman-compose.amd64.yml restart
+```
+
+## Stopping and Updating
+
+### Stop the Service
+
+```bash
+podman-compose -f podman-compose.amd64.yml down
+
+# Remove volumes too (WARNING: deletes models)
+podman-compose -f podman-compose.amd64.yml down -v
+```
+
+### Update Ollama Image
+
+```bash
+# Pull the latest image
+podman pull docker.io/ollama/ollama
+
+# Restart the service
+podman-compose -f podman-compose.amd64.yml restart
+```
+
+### Backup Models
+
+Before updating or removing volumes:
+
+```bash
+# Export the container image with loaded models
+podman commit ollama-llm-capability ollama-llm-backup:latest
+
+# Or backup the volume
+podman run --rm \
+  -v ollama-data:/data \
+  -v $(pwd):/backup \
+  alpine tar czf /backup/ollama-backup.tar.gz -C /data .
+```
+
+## Security Considerations
+
+### Network Exposure
+
+The Ollama API is exposed on port 11434. By default, it's only accessible locally. For remote access:
+
+1. **Use a firewall:**
+   ```bash
+   sudo ufw allow from 192.168.1.0/24 to any port 11434
+   ```
+
+2. **Use a reverse proxy (nginx):**
+   ```nginx
+   server {
+       listen 80;
+       server_name ollama.example.com;
+       
+       location / {
+           proxy_pass http://localhost:11434;
+           proxy_buffering off;
+       }
+   }
+   ```
+
+3. **Use authentication:**
+   Consider wrapping the API with an authentication layer for production.
+
+## Advanced Configuration
+
+### Custom Environment Variables
+
+```yaml
+environment:
+  - OLLAMA_NUM_PARALLEL=8
+  - OLLAMA_MAX_LOADED_MODELS=3
+  - OLLAMA_LOAD_TIMEOUT=5m  # Model load timeout
+  - OLLAMA_KEEP_ALIVE=5m    # Keep model in memory for 5 minutes
+```
+
+### Custom Model Directory
+
+```yaml
+volumes:
+  - /path/to/custom/models:/root/.ollama
+```
+
+### Running Multiple Instances
+
+If you need multiple Ollama instances on the same machine:
+
+```bash
+# Use different ports and container names
+podman run -d \
+  --name ollama-instance-2 \
+  -p 11435:11434 \
+  -v ollama-data-2:/root/.ollama \
+  docker.io/ollama/ollama
+```
+
+## Next Steps
+
+1. **Verify deployment:** Run `./scripts/health-check.sh`
+2. **Pull your first model:** Follow Model Management section above
+3. **Test the API:** Use the API Usage examples
+4. **Integrate with eZansiEdgeAI:** See the main README for capability registry configuration
+5. **Monitor performance:** Use the Performance Optimization section for your workload
+
+## Support & Troubleshooting
+
+For additional issues:
+
+1. Check [troubleshooting.md](troubleshooting.md) for common issues
+2. Review [architecture.md](architecture.md) for system design
+3. See [performance-tuning.md](performance-tuning.md) for optimization
+4. Check Ollama documentation: https://github.com/ollama/ollama

--- a/docs/deployment-guide.md
+++ b/docs/deployment-guide.md
@@ -40,7 +40,9 @@ podman run -d myregistry.com/ollama-capability:latest
 
 ## Option 3: Rebuild on Target (Optimized)
 
-Copy the `Containerfile` and build locally on the target system:
+This repo deploys the upstream multi-architecture image (`docker.io/ollama/ollama`). There is no `Containerfile` in this repo today.
+
+For best compatibility across architectures, deploy on the target device using the provided compose files:
 
 ```bash
 # Transfer this repo
@@ -48,8 +50,12 @@ scp -r <this-repo> user@raspberrypi:
 
 # On target machine
 cd <this-repo>
-podman build -t ollama-capability:latest .
-podman run -d ollama-capability:latest
+
+# Raspberry Pi (ARM64)
+podman-compose up -d
+
+# AMD64 (x86-64)
+podman-compose -f config/amd64-24gb.yml up -d
 ```
 
 **Best for:** Optimizing for target architecture, minimal initial transfer, bandwidth-constrained environments  
@@ -57,9 +63,11 @@ podman run -d ollama-capability:latest
 
 ## Cross-Architecture Considerations
 
-- **x86 → ARM (Raspberry Pi):** Use Option 3 (rebuild) for best compatibility
+- **x86 → ARM (Raspberry Pi):** Deploy on the Pi using `podman-compose` (avoid moving preloaded images across architectures)
 - **ARM → ARM (Pi 4 → Pi 5):** Options 1-2 work well, same architecture
 - **Mixed fleet:** Use Option 2 (registry) with multi-architecture builds
+
+For a dedicated AMD64 walkthrough, see [deployment-guide-amd64.md](deployment-guide-amd64.md).
 
 ## Quick Start: Deploy to Raspberry Pi 5
 
@@ -80,4 +88,4 @@ podman run -d \
 ./scripts/health-check.sh
 ```
 
-See [DEPLOYMENT.md](../README.md) for additional configuration options.
+See [README.md](../README.md) for additional configuration options.

--- a/docs/development-roadmap.md
+++ b/docs/development-roadmap.md
@@ -4,7 +4,7 @@ This document outlines the multi-phase plan for building the eZansiEdgeAI capabi
 
 ## Phase 1: Validate Base Capability ✓ (Current)
 
-**Status:** Base Ollama capability is deployed and tested on Pi 5
+**Status:** Base Ollama capability is deployed and tested on Pi 5 (ARM64), and supported on AMD64 (x86-64) for development and higher-performance deployments.
 
 1. **Pull a model and test text generation**
    ```bash
@@ -35,7 +35,7 @@ This document outlines the multi-phase plan for building the eZansiEdgeAI capabi
    - Follow same pattern as capability-llm-ollama
    - Own capability.json contract
    - Separate repository
-   - Target device: Raspberry Pi 5
+   - Target device: Raspberry Pi 5 (primary edge target); AMD64 support encouraged for dev/test
 
 ### New Capability Repository Structure
 
@@ -46,6 +46,7 @@ ezansi-capability-stt-whisper/
 ├── capability.json           # Contract: defines service interface
 ├── podman-compose.yml        # Deployment: container configuration
 ├── podman-compose.pi5.yml    # Device-specific: optimized for Pi 5
+├── podman-compose.amd64.yml  # Optional: device-specific preset for AMD64 (24GB+)
 ├── README.md                 # Quick start & overview
 ├── CHANGELOG.md              # Version history
 ├── LICENSE                   # License
@@ -57,6 +58,8 @@ ezansi-capability-stt-whisper/
 ├── config/
 │   ├── pi5-16gb.yml          # Pi 5 constraints
 │   ├── pi4-8gb.yml           # Pi 4 constraints
+│   ├── amd64-24gb.yml         # Optional: AMD64 constraints (24GB+)
+│   ├── amd64-32gb.yml         # Optional: AMD64 constraints (32GB+)
 │   └── device-constraints.json
 ├── tests/
 │   ├── test-api.sh           # API functionality

--- a/docs/performance-tuning.md
+++ b/docs/performance-tuning.md
@@ -1,6 +1,6 @@
 # Performance Tuning Guide
 
-## Raspberry Pi Optimization
+## Raspberry Pi Optimization (ARM64)
 
 ### Hardware Considerations
 
@@ -9,6 +9,37 @@
 | Pi 5 (16GB) | 16GB | mistral, llama2, neural-chat | 8GB | 4 |
 | Pi 5 (8GB) | 8GB | mistral, neural-chat, orca-mini | 6GB | 2 |
 | Pi 4 (8GB) | 8GB | neural-chat, orca-mini, tinyllama | 5GB | 2 |
+
+## AMD64 Optimization (x86-64)
+
+AMD64 systems typically have more RAM/CPU available than Raspberry Pi, so you can safely raise memory limits and parallelism.
+
+### Recommended Presets
+
+| Host RAM | Config | Container Memory Limit | CPUs | Notes |
+|----------|--------|------------------------|------|-------|
+| 24GB | `config/amd64-24gb.yml` | 18GB | 8 | Good default for laptops/workstations |
+| 32GB+ | `config/amd64-32gb.yml` | 28GB | 16 | Higher throughput, more models resident |
+| 24GB+ | `podman-compose.amd64.yml` | 20GB | 8 | Simple default for servers |
+
+### AMD64 Model Selection
+
+With an ~18–20GB container limit, expect best results with 7B-class models:
+
+- Good defaults: `mistral`, `llama2:7b`, `neural-chat`, `codellama:7b`
+- Smaller/faster: `phi`, `orca-mini`, `tinyllama`
+
+For 13B-class models, raise the container memory limit (e.g., use `config/amd64-32gb.yml`) and reduce `OLLAMA_NUM_PARALLEL`.
+
+### Environment Variables
+
+```yaml
+environment:
+  - OLLAMA_NUM_PARALLEL=8
+  - OLLAMA_MAX_LOADED_MODELS=3
+```
+
+If you see latency spikes or memory pressure during concurrent requests, lower `OLLAMA_NUM_PARALLEL` first.
 
 ### Resource Allocation
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -2,6 +2,12 @@
 
 ## Common Issues and Solutions
 
+Note: Several scripts and examples use `curl`. On minimal Linux installs you may need to install it first:
+
+```bash
+sudo apt update && sudo apt install -y curl
+```
+
 ### Container Won't Start
 
 #### Symptoms
@@ -87,6 +93,11 @@ curl -I https://docker.io
 - Connection refused errors
 
 #### Solutions
+
+**If you see `curl: command not found`:**
+```bash
+sudo apt update && sudo apt install -y curl
+```
 
 **Wait for container to fully start:**
 ```bash
@@ -184,6 +195,8 @@ podman restart ollama-llm-capability
 vcgencmd measure_temp
 # If > 80°C, improve cooling
 ```
+
+`vcgencmd` is Raspberry Pi specific. On AMD64, use `sensors` / `lm-sensors` or `watch -n1 cat /sys/class/thermal/thermal_zone*/temp`.
 
 **Use appropriate model for hardware:**
 

--- a/podman-compose.amd64.yml
+++ b/podman-compose.amd64.yml
@@ -1,0 +1,35 @@
+version: '3.8'
+
+# Configuration for AMD64 Systems (24GB+ RAM)
+# Optimized for x86-64 servers and workstations
+
+services:
+  ollama:
+    image: docker.io/ollama/ollama
+    container_name: ollama-llm-capability
+    platform: linux/amd64
+    ports:
+      - "11434:11434"
+    volumes:
+      - ollama-data:/root/.ollama
+    deploy:
+      resources:
+        limits:
+          memory: 20g
+          cpus: '8'
+        reservations:
+          memory: 16g
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:11434/api/tags"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
+    environment:
+      - OLLAMA_NUM_PARALLEL=8
+      - OLLAMA_MAX_LOADED_MODELS=3
+
+volumes:
+  ollama-data:
+    driver: local


### PR DESCRIPTION
## Summary
Adds first-class AMD64 (x86-64) deployment support alongside Raspberry Pi (ARM64).

## What's Included
- AMD64 Podman compose + presets for 24GB/32GB class hosts
- Dedicated AMD64 deployment guide
- Capability contract + device constraints updated for multi-arch metadata
- Docs updated to be dual-arch (Pi + AMD64)
- Repo hygiene: issue templates and docs sync guidance

## Notes
- Keeps Pi as the default target; AMD64 is supported and documented.
- Models live in volumes; container images are separate from model data.

## Checklist
- [x] Docs updated
- [x] Deployment presets added
- [x] Backward compatible contract guidance