### PR TITLE
Add stop helper script

### DIFF
--- a/README.md
+++ b/README.md
@@ -400,7 +400,14 @@ podman stats ollama-llm-capability
 ### Stop the Container
 
 ```bash
-podman-compose down
+./scripts/stop.sh --down
+```
+
+If you have multiple capability containers running and want to stop just one, use:
+
+```bash
+./scripts/stop.sh --list
+./scripts/stop.sh
 ```
 
 This stops the container but preserves model data in the volume.

--- a/scripts/stop.sh
+++ b/scripts/stop.sh
@@ -1,0 +1,142 @@
+#!/bin/bash
+set -euo pipefail
+
+# Stop the stack (or selected containers) using Podman.
+#
+# Usage:
+#   ./scripts/stop.sh                # interactive (if TTY), otherwise podman-compose down
+#   ./scripts/stop.sh --down         # podman-compose down (recommended)
+#   ./scripts/stop.sh --profile pi5 --down
+#   ./scripts/stop.sh --list         # list matching containers
+#   ./scripts/stop.sh --rm           # remove selected containers (podman rm -f)
+#   MATCH_REGEX='ollama' ./scripts/stop.sh --list
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+PROFILE="${PROFILE:-}"
+DOWN=false
+LIST=false
+REMOVE=false
+
+if [[ ${1:-} == "--profile" ]]; then
+	PROFILE="${2:-}"
+	shift 2
+fi
+
+while [[ $# -gt 0 ]]; do
+	case "$1" in
+		--down)
+			DOWN=true
+			shift
+			;;
+		--list)
+			LIST=true
+			shift
+			;;
+		--rm)
+			REMOVE=true
+			shift
+			;;
+		*)
+			echo "Unknown arg: $1" >&2
+			echo "Usage: ./scripts/stop.sh [--profile pi5] [--down] [--list] [--rm]" >&2
+			exit 2
+			;;
+	esac
+done
+
+MATCH_REGEX="${MATCH_REGEX:-ollama-llm-capability}"
+
+compose_down() {
+	command -v podman-compose >/dev/null 2>&1 || { echo "podman-compose is required" >&2; exit 1; }
+
+	# This repo's pi5 compose file is standalone (not an override).
+	if [[ "$PROFILE" == "pi5" ]]; then
+		podman-compose -f podman-compose.pi5.yml down
+	else
+		podman-compose down
+	fi
+}
+
+list_containers() {
+	command -v podman >/dev/null 2>&1 || { echo "podman is required" >&2; exit 1; }
+	podman ps --format '{{.ID}}\t{{.Names}}\t{{.Status}}' \
+		| awk -v re="$MATCH_REGEX" '$2 ~ re {print}'
+}
+
+if $DOWN; then
+	compose_down
+	echo "OK"
+	exit 0
+fi
+
+matches="$(list_containers || true)"
+if [[ -z "$matches" ]]; then
+	echo "No matching running containers (MATCH_REGEX=$MATCH_REGEX)."
+	printf '%s\n' "Tip: list all containers with: podman ps --format 'table {{.Names}}\t{{.Status}}\t{{.Ports}}'"
+	exit 0
+fi
+
+if $LIST; then
+	echo "$matches" | awk 'BEGIN{print "CONTAINER_ID\tNAME\tSTATUS"} {print}'
+	exit 0
+fi
+
+# Default: if non-interactive, just compose down (most reliable way to stop the stack).
+if [[ ! -t 0 ]]; then
+	compose_down
+	echo "OK"
+	exit 0
+fi
+
+# Interactive selection.
+mapfile -t rows < <(printf '%s\n' "$matches")
+
+echo "Select a container to stop${REMOVE:+ (remove)}:"
+for i in "${!rows[@]}"; do
+	name="$(echo "${rows[$i]}" | awk '{print $2}')"
+	status="$(echo "${rows[$i]}" | cut -f3- | sed 's/^\s*//')"
+	printf '  [%d] %s\t%s\n' "$((i+1))" "$name" "$status"
+done
+
+echo "  [a] all matching containers"
+echo "  [d] podman-compose down (recommended)"
+echo "  [q] quit"
+
+read -r -p "Choice: " choice
+
+case "$choice" in
+	q|Q)
+		exit 0
+		;;
+	d|D)
+		compose_down
+		;;
+	a|A)
+		if $REMOVE; then
+			printf '%s\n' "$matches" | awk '{print $2}' | xargs -r podman rm -f
+		else
+			printf '%s\n' "$matches" | awk '{print $2}' | xargs -r podman stop
+		fi
+		;;
+	*)
+		if ! [[ "$choice" =~ ^[0-9]+$ ]]; then
+			echo "Invalid choice." >&2
+			exit 2
+		fi
+		idx=$((choice-1))
+		if (( idx < 0 || idx >= ${#rows[@]} )); then
+			echo "Invalid choice." >&2
+			exit 2
+		fi
+		name="$(echo "${rows[$idx]}" | awk '{print $2}')"
+		if $REMOVE; then
+			podman rm -f "$name"
+		else
+			podman stop "$name"
+		fi
+		;;
+esac
+
+echo "OK"


### PR DESCRIPTION
### Why
When multiple eZansi capabilities are running, it’s easy to hit container-name conflicts or stop the wrong container.

### What
- Adds scripts/stop.sh to list matching running containers and stop either a single container (interactive) or the full stack (podman-compose down).
- Updates README stop instructions to reference the helper.

### Usage
- ./scripts/stop.sh --list
- ./scripts/stop.sh
- ./scripts/stop.sh --down
