### PR TITLE
docs: add LEGO-brick framing for learners

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Podman/Docker artifacts
 *.log
 .podman/
+ollama-capability-image.tar
 
 # Ollama data (local development)
 ollama-data/

--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@ Ollama LLM Capability for eZansiEdgeAI — a modular, containerized text-generat
 **Target devices:** Raspberry Pi 4/5 (ARM64) and AMD64 hosts (24GB+)  
 **Deployment method:** Podman + podman-compose
 
+## Quickstart Manual Test
+
+- Standalone + via platform-core gateway: [docs/quickstart-manual-test.md](docs/quickstart-manual-test.md)
+
 ---
 
 ## Deployment Plan

--- a/README.md
+++ b/README.md
@@ -6,6 +6,16 @@ Ollama LLM Capability for eZansiEdgeAI — a modular, containerized text-generat
 **Target devices:** Raspberry Pi 4/5 (ARM64) and AMD64 hosts (24GB+)  
 **Deployment method:** Podman + podman-compose
 
+## Mental model (LEGO brick)
+
+If you’re a teacher/lecturer or student, think of this repo as **one LEGO brick** in an edge‑AI kit:
+
+- This capability provides the LLM “brick” (text generation)
+- `capability.json` describes the “studs” (what this brick can do)
+- [eZansi Platform Core](https://github.com/eZansiEdgeAI/ezansi-platform-core) is the “baseplate” (one gateway that discovers bricks and routes requests)
+
+For a cold-start checklist (standalone + via the gateway), start here:
+
 ## Quickstart Manual Test
 
 - Standalone + via platform-core gateway: [docs/quickstart-manual-test.md](docs/quickstart-manual-test.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,6 +4,9 @@ Comprehensive documentation for the Ollama LLM Capability.
 
 ## Core Documentation
 
+### [Quickstart Manual Test](quickstart-manual-test.md)
+Cold-start checklist: deploy, pull a model, and validate end-to-end (standalone + via platform-core).
+
 ### [Architecture](architecture.md)
 System architecture, design principles, and component responsibilities.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,6 +2,15 @@
 
 Comprehensive documentation for the Ollama LLM Capability.
 
+## Mental model (LEGO brick)
+
+If you’re a teacher/lecturer or student, think of this capability as **one LEGO brick**.
+
+- `capability.json` describes the “studs” (what this brick provides)
+- [eZansi Platform Core](https://github.com/eZansiEdgeAI/ezansi-platform-core) is the “baseplate” (one gateway that discovers bricks and routes requests)
+
+Start with the cold-start checklist: [Quickstart Manual Test](quickstart-manual-test.md)
+
 ## Core Documentation
 
 ### [Quickstart Manual Test](quickstart-manual-test.md)

--- a/docs/quickstart-manual-test.md
+++ b/docs/quickstart-manual-test.md
@@ -1,0 +1,73 @@
+# Quickstart Manual Test (Cold Start)
+
+This is a manual test checklist for the `ezansi-capability-llm-ollama` capability.
+
+Goal: prove the capability works standalone, then prove it can be invoked via the `ezansi-platform-core` gateway.
+
+## Prerequisites
+
+- `podman`, `podman-compose`
+- `curl`
+
+## 1) Cold start: deploy Ollama
+
+From the repo root:
+
+```bash
+podman-compose up -d
+```
+
+Verify Ollama API is reachable:
+
+```bash
+curl -fsS http://localhost:11434/api/tags
+```
+
+## 2) Pull a model (first run)
+
+On a cold machine, you must download at least one model:
+
+```bash
+./scripts/pull-model.sh mistral
+```
+
+## 3) Standalone request (direct to Ollama)
+
+```bash
+curl -fsS -X POST http://localhost:11434/api/generate \
+  -H 'Content-Type: application/json' \
+  -d '{"model":"mistral","prompt":"Hello from Ollama","stream":false}'
+```
+
+Success looks like: JSON containing `response`.
+
+## 4) Invoke via ezansi-platform-core gateway (integration)
+
+This requires:
+
+- `ezansi-platform-core` running on `http://localhost:8000`
+- the capability contract copied into the platform registry folder
+
+Example (from the platform-core repo root):
+
+```bash
+mkdir -p capabilities/ollama-llm
+cp ../ezansi-capability-llm-ollama/capability.json capabilities/ollama-llm/capability.json
+podman-compose up -d --build
+```
+
+Then call through the gateway:
+
+```bash
+curl -fsS -X POST http://localhost:8000/ \
+  -H 'Content-Type: application/json' \
+  -d '{"type":"text-generation","payload":{"endpoint":"generate","json":{"model":"mistral","prompt":"Hello via platform-core","stream":false}}}'
+```
+
+Success looks like: a JSON response containing generated text.
+
+## Teardown
+
+```bash
+./scripts/stop.sh --down
+```

--- a/docs/quickstart-manual-test.md
+++ b/docs/quickstart-manual-test.md
@@ -2,6 +2,16 @@
 
 This is a manual test checklist for the `ezansi-capability-llm-ollama` capability.
 
+## What this is (LEGO bricks for learning)
+
+If you’re a teacher/lecturer or student (school → university), think of eZansiEdgeAI as **LEGO bricks for edge AI**:
+
+- **This repo = one brick** (an LLM capability powered by Ollama)
+- **`capability.json` = the studs** (it declares what this brick provides)
+- **`ezansi-platform-core` = the baseplate/gateway** (it discovers bricks and routes requests)
+
+This quickstart proves the brick works on its own, then proves it “clicks in” through Platform Core.
+
 Goal: prove the capability works standalone, then prove it can be invoked via the `ezansi-platform-core` gateway.
 
 ## Prerequisites


### PR DESCRIPTION
Adds learner-friendly LEGO-brick mental model framing to docs and README, and updates the manual quickstart to match the Platform Core onboarding story.

Changes:
- README: add short mental model section linking to Platform Core
- docs/README.md: add same mental model section
- docs/quickstart-manual-test.md: add education-first LEGO-bricks framing