### PR TITLE
feat: enhance model pull progress display with detailed status updates

### DIFF
--- a/scripts/pull-model.sh
+++ b/scripts/pull-model.sh
@@ -24,10 +24,36 @@ echo "Pulling model: $MODEL_NAME..."
 echo "This may take several minutes depending on model size and internet speed."
 echo ""
 
-# Pull the model
-curl -X POST http://localhost:11434/api/pull \
+# Pull the model (single-line progress)
+# Streams JSON progress from the Ollama API, splits concatenated objects,
+# extracts status/total/completed, and renders a human-readable progress line.
+curl -sN -X POST http://localhost:11434/api/pull \
     -d "{\"name\":\"$MODEL_NAME\"}" \
-    -H "Content-Type: application/json"
+    -H "Content-Type: application/json" \
+| sed -u 's/}{/}\n{/g' \
+| while IFS= read -r line; do
+    # Skip empty lines
+    [ -z "$line" ] && continue
+
+    # Extract fields from JSON line
+    status=$(printf '%s' "$line" | sed -n 's/.*"status":"\([^"]*\)".*/\1/p')
+    total=$(printf '%s' "$line" | sed -n 's/.*"total":\([0-9]*\).*/\1/p')
+    completed=$(printf '%s' "$line" | sed -n 's/.*"completed":\([0-9]*\).*/\1/p')
+
+    # Render progress
+    if [ -n "$status" ] && [ -n "$total" ] && [ -n "$completed" ] && [ "$total" -gt 0 ] 2>/dev/null; then
+        percent=$((completed * 100 / total))
+        completed_h=$(awk -v b="$completed" 'function human(x){u="B KB MB GB TB PB"; n=split(u,a," "); i=1; while (x>=1024 && i<n){x/=1024; i++} printf "%.3f%s", x, a[i]} BEGIN{human(b)}')
+        total_h=$(awk -v b="$total" 'function human(x){u="B KB MB GB TB PB"; n=split(u,a," "); i=1; while (x>=1024 && i<n){x/=1024; i++} printf "%.3f%s", x, a[i]} BEGIN{human(b)}')
+        printf "\r\033[K%s %3d%% (%s/%s)" "$status" "$percent" "$completed_h" "$total_h"
+    else
+        printf "\r\033[K%s" "$line"
+    fi
+
+    if [ "$status" = "success" ]; then
+        printf "\n"
+    fi
+done
 
 echo ""
 echo "================================================"


### PR DESCRIPTION
This pull request enhances the user experience of the `pull-model.sh` script by adding a real-time, human-readable progress indicator when pulling models from the Ollama API. Instead of displaying raw JSON output, the script now parses the streamed progress updates and displays percentage completion and data transferred in a more readable format.

**Improvements to model download progress display:**

* Updated the model pulling logic in `pull-model.sh` to stream JSON progress from the Ollama API, parse the status, total, and completed fields, and display a single-line progress update with percentage and human-readable data sizes.