### PR TITLE
pull-model: prompt for model when no args

### DIFF
--- a/scripts/pull-model.sh
+++ b/scripts/pull-model.sh
@@ -2,21 +2,153 @@
 
 # Pull and configure a model for Ollama
 # Usage: ./pull-model.sh <model-name>
+#        ./pull-model.sh --recommended
 
 set -e
 
-MODEL_NAME="${1:-mistral}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+usage() {
+    cat <<'EOF'
+Usage:
+    ./scripts/pull-model.sh <model-name>
+    ./scripts/pull-model.sh
+  ./scripts/pull-model.sh --recommended
+  ./scripts/pull-model.sh --recommended-raw
+  ./scripts/pull-model.sh --help
+
+Description:
+  Pull a model into your local Ollama instance (http://localhost:11434).
+        When run with no arguments, this script prints recommended models for your
+        device (from ./scripts/choose-compose.sh --models), prompts for a model
+        name, then pulls that model.
+
+Options:
+  --recommended       Print recommended models (friendly format) and exit.
+  --recommended-raw   Print recommended models (raw; one per line) and exit.
+  -h, --help          Show this help.
+EOF
+}
+
+list_recommended_models() {
+    if [ ! -x "$SCRIPT_DIR/choose-compose.sh" ]; then
+        echo "Error: scripts/choose-compose.sh not found or not executable" >&2
+        echo "Expected: $SCRIPT_DIR/choose-compose.sh" >&2
+        return 2
+    fi
+
+    echo "================================================"
+    echo "Recommended models (from choose-compose)"
+    echo "================================================"
+    if ! "$SCRIPT_DIR/choose-compose.sh" --models | sed 's/^/- /'; then
+        echo "" >&2
+        echo "Tip: run ./scripts/choose-compose.sh to see why device detection failed." >&2
+        return 3
+    fi
+
+    return 0
+}
+
+print_recommended_models_and_exit() {
+    local raw="$1"
+
+    if [ ! -x "$SCRIPT_DIR/choose-compose.sh" ]; then
+        echo "Error: scripts/choose-compose.sh not found or not executable" >&2
+        echo "Expected: $SCRIPT_DIR/choose-compose.sh" >&2
+        exit 2
+    fi
+
+    if [ "$raw" = "1" ]; then
+        "$SCRIPT_DIR/choose-compose.sh" --models
+        exit $?
+    fi
+
+    if ! list_recommended_models; then
+        exit $?
+    fi
+
+    echo ""
+    echo "Pull one with: ./scripts/pull-model.sh <model-name>"
+    exit 0
+}
+
+prompt_for_model_name() {
+    local __out_var="$1"
+    local input=""
+
+    echo "" >&2
+    echo "Type a model name to pull, or press Enter to exit." >&2
+
+    if [ -t 0 ]; then
+        # Normal interactive use.
+        read -r -p "Model name: " input
+    elif [ -t 1 ] && [ -r /dev/tty ]; then
+        # stdin may have been consumed by earlier pipelines; read directly from the terminal.
+        read -r -p "Model name: " input </dev/tty
+    else
+        # Non-interactive stdin (e.g. piped). If there's no input (EOF), exit.
+        if ! IFS= read -r input; then
+            return 1
+        fi
+    fi
+
+    # Trim leading/trailing whitespace
+    input="$(printf '%s' "$input" | sed 's/^[[:space:]]\+//; s/[[:space:]]\+$//')"
+    if [ -z "$input" ]; then
+        return 1
+    fi
+
+    printf -v "$__out_var" '%s' "$input"
+    return 0
+}
+
+case "${1:-}" in
+    --interactive)
+        # Alias: previous iteration used --interactive.
+        print_recommended_models_and_exit 0
+        ;;
+    --recommended)
+        print_recommended_models_and_exit 0
+        ;;
+    --recommended-raw)
+        print_recommended_models_and_exit 1
+        ;;
+    -h|--help)
+        usage
+        exit 0
+        ;;
+esac
+
+MODEL_NAME="${1:-}"
+if [ -z "$MODEL_NAME" ]; then
+    if ! list_recommended_models; then
+        echo "" >&2
+        echo "(Continuing: you can still type a model name manually.)" >&2
+    fi
+
+    echo ""
+    echo "Pull one with: ./scripts/pull-model.sh <model-name>"
+
+    if ! prompt_for_model_name MODEL_NAME; then
+        exit 0
+    fi
+fi
 
 echo "================================================"
 echo "Ollama Model Puller"
 echo "================================================"
 echo "Model: $MODEL_NAME"
+echo "Ollama: http://localhost:11434"
 echo ""
 
 # Check if Ollama is running
-if ! curl -s http://localhost:11434/api/tags > /dev/null 2>&1; then
-    echo "Error: Ollama is not running or not accessible on port 11434"
-    echo "Start it with: podman-compose up -d"
+echo "Checking Ollama..."
+if ! curl -fsS \
+    --connect-timeout 2 \
+    --max-time 5 \
+    http://localhost:11434/api/tags >/dev/null; then
+    echo "Error: Ollama is not running or not reachable at http://localhost:11434" >&2
+    echo "Start it with: podman-compose up -d" >&2
     exit 1
 fi
 
@@ -30,6 +162,8 @@ echo ""
 curl -sN -X POST http://localhost:11434/api/pull \
     -d "{\"name\":\"$MODEL_NAME\"}" \
     -H "Content-Type: application/json" \
+    --connect-timeout 2 \
+    --max-time 0 \
 | sed -u 's/}{/}\n{/g' \
 | while IFS= read -r line; do
     # Skip empty lines
@@ -61,7 +195,7 @@ echo "Model pull complete!"
 echo "================================================"
 echo ""
 echo "Test it with:"
-echo "curl -X POST http://localhost:11434/api/generate \\"
-echo "  -d '{\"model\":\"$MODEL_NAME\",\"prompt\":\"Hello\"}' \\"
-echo "  -H \"Content-Type: application/json\""
+echo "curl -X POST http://localhost:11434/api/generate \\" 
+echo "  -H 'Content-Type: application/json' \\"
+echo "  -d '{\"model\":\"$MODEL_NAME\",\"prompt\":\"Hello\"}'"
 echo ""


### PR DESCRIPTION
## What
- Improves `./scripts/pull-model.sh` UX when run with no args: it now prints the recommended models (from `./scripts/choose-compose.sh --models`), then prompts for a model name and pulls it.
- Keeps `--recommended` and `--recommended-raw` as list-and-exit options.
- Removes env-var configuration for the Ollama URL/timeouts; uses `http://localhost:11434` with sane curl timeouts for a simpler, predictable script.

## Why
- The previous behavior required an explicit model argument or would just exit after listing, which made the common workflow slower (especially for new users).

## How to use
- `./scripts/pull-model.sh` → show list, then type a model (or Enter to exit)
- `./scripts/pull-model.sh <model>` → pull directly
- `./scripts/pull-model.sh --recommended` → list recommended models (friendly)
- `./scripts/pull-model.sh --recommended-raw` → list recommended models (raw)

## Testing
- `bash -n scripts/pull-model.sh`
- `./scripts/pull-model.sh --recommended-raw`
- Manual: run `./scripts/pull-model.sh`, enter a model name, confirm pull starts